### PR TITLE
Revert breaking changes from 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.9.0 2019-01-23
+### Changed
+- Reverted release 0.7.0 changes as they broke existing library clients.
+
+## 0.8.0 2019-01-20
+### Changed
+- Updated Jackson version in response to GitHub security alert.
+
 ## 0.7.0 2019-01-17
 ### Changed
 - Metrictank interval and org_id are now stored as metatags instead of tags. This makes it possible to use tags with those names, however metrics serialised with earlier versions of metrics-java will not be compatible with this release.

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.expedia</groupId>
         <artifactId>metrics-java-root</artifactId>
-        <version>0.8.0</version>
+        <version>0.9.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.expedia</groupId>
         <artifactId>metrics-java-root</artifactId>
-        <version>0.8.0</version>
+        <version>0.9.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 </project>

--- a/metrictank/pom.xml
+++ b/metrictank/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.expedia</groupId>
         <artifactId>metrics-java-root</artifactId>
-        <version>0.8.0</version>
+        <version>0.9.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/metrictank/src/main/java/com/expedia/metrics/metrictank/MessagePackSerializer.java
+++ b/metrictank/src/main/java/com/expedia/metrics/metrictank/MessagePackSerializer.java
@@ -33,11 +33,11 @@ import java.util.*;
 public class MessagePackSerializer implements MetricDataSerializer {
     public static final String ORG_ID = "org_id";
     public static final String INTERVAL = "interval";
-
+    
     private static final int METRIC_NUM_FIELDS = 9;
-
+    
     private final MetricTankIdFactory idFactory = new MetricTankIdFactory();
-
+    
     @Override
     public byte[] serialize(MetricData metric) throws IOException {
         final MessageBufferPacker packer = MessagePack.newDefaultBufferPacker();
@@ -45,7 +45,7 @@ public class MessagePackSerializer implements MetricDataSerializer {
         packer.close();
         return packer.toByteArray();
     }
-
+    
     @Override
     public byte[] serializeList(List<MetricData> metrics) throws IOException {
         final MessageBufferPacker packer = MessagePack.newDefaultBufferPacker();
@@ -56,7 +56,7 @@ public class MessagePackSerializer implements MetricDataSerializer {
         packer.close();
         return packer.toByteArray();
     }
-
+    
     public MetricData deserialize(ByteBuffer buffer) throws IOException {
         try {
             final MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(buffer);
@@ -67,13 +67,13 @@ public class MessagePackSerializer implements MetricDataSerializer {
             throw new IOException("Unable to deserialize MetricData", e);
         }
     }
-
+    
     @Override
     public MetricData deserialize(byte[] bytes) throws IOException {
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         return deserialize(buffer);
     }
-
+    
     public List<MetricData> deserializeList(ByteBuffer buffer) throws IOException {
         final MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(buffer);
         final int numMetrics = unpacker.unpackArrayHeader();
@@ -84,35 +84,37 @@ public class MessagePackSerializer implements MetricDataSerializer {
         unpacker.close();
         return metrics;
     }
-
+    
     @Override
     public List<MetricData> deserializeList(byte[] bytes) throws IOException {
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         return deserializeList(buffer);
     }
-
+    
     private void serialize(MetricData metric, MessagePacker packer) throws IOException {
         final String name = metric.getMetricDefinition().getKey();
         if (name == null) {
             throw new IOException("Key is required by metrictank");
         }
+        if (!metric.getMetricDefinition().getMeta().isEmpty()) {
+            throw new IOException("Metrictank does not support meta tags");
+        }
         if (!metric.getMetricDefinition().getTags().getV().isEmpty()) {
             throw new IOException("Metrictank does not support value tags");
         }
-        Map<String, String> metaTags = metric.getMetricDefinition().getMeta().getKv();
+        Map<String, String> tags = new HashMap<>(metric.getMetricDefinition().getTags().getKv());
         final int orgId;
         try {
-            orgId = Integer.parseInt(metaTags.get(ORG_ID));
+            orgId = Integer.parseInt(tags.remove(ORG_ID));
         } catch (NumberFormatException e) {
             throw new IOException("Tag 'org_id' must be an int", e);
         }
         final int interval;
         try {
-            interval = Integer.parseInt(metaTags.get(INTERVAL));
+            interval = Integer.parseInt(tags.remove(INTERVAL));
         } catch (NumberFormatException e) {
             throw new IOException("Tag 'interval' must be an int", e);
         }
-        Map<String, String> tags = new HashMap<>(metric.getMetricDefinition().getTags().getKv());
         final String unit = tags.remove(MetricDefinition.UNIT);
         if (unit == null) {
             throw new IOException("Tag 'unit' is required by metrictank");
@@ -123,7 +125,7 @@ public class MessagePackSerializer implements MetricDataSerializer {
         }
         List<String> formattedTags = idFactory.formatTags(tags);
         final String id = idFactory.getId(orgId, name, unit, mtype, interval, formattedTags);
-
+        
         packer.packMapHeader(METRIC_NUM_FIELDS);
         packer.packString("Id");
         packer.packString(id);
@@ -138,13 +140,13 @@ public class MessagePackSerializer implements MetricDataSerializer {
         packer.packString("Unit");
         packer.packString(unit);
         packer.packString("Time");
-
+        
         // packLong auto converts to narrowest int type, but Raintank requires a signed int64, so we manually pack the time
         final ByteBuffer b = ByteBuffer.allocate(1 + Long.BYTES);
         b.put(MessagePack.Code.INT64);
         b.putLong(metric.getTimestamp());
         packer.addPayload(b.array());
-
+        
         packer.packString("Mtype");
         packer.packString(mtype);
         packer.packString("Tags");
@@ -153,7 +155,7 @@ public class MessagePackSerializer implements MetricDataSerializer {
             packer.packString(tag);
         }
     }
-
+    
     private MetricData deserialize(MessageUnpacker unpacker) throws IOException {
         int orgId = 0;
         String name = "";
@@ -173,22 +175,22 @@ public class MessagePackSerializer implements MetricDataSerializer {
                     orgId = unpacker.unpackInt();
                     break;
                 case "Name":
-                name = unpacker.unpackString();
+                    name = unpacker.unpackString();
                     break;
                 case "Interval":
-                interval = unpacker.unpackInt();
+                    interval = unpacker.unpackInt();
                     break;
                 case "Value":
-                value = unpacker.unpackDouble();
+                    value = unpacker.unpackDouble();
                     break;
                 case "Unit":
-                unit = unpacker.unpackString();
+                    unit = unpacker.unpackString();
                     break;
                 case "Time":
-                timestamp = unpacker.unpackLong();
+                    timestamp = unpacker.unpackLong();
                     break;
                 case "Mtype":
-                mtype = unpacker.unpackString();
+                    mtype = unpacker.unpackString();
                     break;
                 case "Tags":
                     final int numTags = unpacker.unpackArrayHeader();
@@ -203,16 +205,16 @@ public class MessagePackSerializer implements MetricDataSerializer {
                     break;
             }
         }
-
+        
         throwIfMissing("OrgId", orgId == 0);
         throwIfMissing("Name", name.isEmpty());
         throwIfMissing("Interval", interval == 0);
         throwIfMissing("Mtype", mtype.isEmpty());
-
-        final Map<String, String> metaKvTags = new HashMap<>();
-        metaKvTags.put(ORG_ID, Integer.toString(orgId));
-        metaKvTags.put(INTERVAL, Integer.toString(interval));
+        
         final Map<String, String> kvTags = new HashMap<>();
+        
+        kvTags.put(ORG_ID, Integer.toString(orgId));
+        kvTags.put(INTERVAL, Integer.toString(interval));
         kvTags.put(MetricDefinition.UNIT, unit);
         kvTags.put(MetricDefinition.MTYPE, mtype);
         for (final String tag : rawTags) {
@@ -221,18 +223,14 @@ public class MessagePackSerializer implements MetricDataSerializer {
                 throw new IOException("Read a tag with no '=': "+tag);
             }
             final String tagKey = tag.substring(0, pos);
-            if (tagKey.equals(MetricDefinition.UNIT) || tagKey.equals(MetricDefinition.MTYPE)) {
-                continue;
-            }
             final String tagValue = tag.substring(pos+1);
             kvTags.put(tagKey, tagValue);
         }
-
+        
         TagCollection tags = new TagCollection(kvTags);
-        TagCollection meta = new TagCollection(metaKvTags);
-        return new MetricData(new MetricDefinition(name, tags, meta), value, timestamp);
+        return new MetricData(new MetricDefinition(name, tags, TagCollection.EMPTY), value, timestamp);
     }
-
+    
     private void throwIfMissing(String fieldName, boolean isMissing) throws IOException {
         if (isMissing) {
             throw new IOException("Missing required field: "+fieldName);

--- a/metrictank/src/test/scala/com/expedia/metrics/metrictank/MessagePackSerializerTest.scala
+++ b/metrictank/src/test/scala/com/expedia/metrics/metrictank/MessagePackSerializerTest.scala
@@ -15,7 +15,7 @@
  */
 package com.expedia.metrics.metrictank
 
-import java.util.Base64
+import java.util.{Base64, Collections}
 
 import com.expedia.metrics.{MetricData, MetricDefinition, TagCollection}
 import org.scalatest.{FunSpec, GivenWhenThen, Matchers}
@@ -30,14 +30,12 @@ class MessagePackSerializerTest extends FunSpec with Matchers with GivenWhenThen
     val serializedMetricList = Base64.getDecoder.decode("kYmiSWTZIjEuZDljOThmNDQ1N2I2YWEwNmEwOGU0MDFiMGZiYzk3N2alT3JnSWQBpE5hbWWhYahJbnRlcnZhbDylVmFsdWXLP+ClpvjzIXmkVW5pdKFQpFRpbWXTAAAAAFtiY8SlTXR5cGWlZ2F1Z2WkVGFnc5A=")
 
     val tags = new TagCollection(Map(
+      MessagePackSerializer.ORG_ID -> "1",
+      MessagePackSerializer.INTERVAL -> "60",
       MetricDefinition.UNIT -> "P",
       MetricDefinition.MTYPE -> "gauge"
     ).asJava)
-    val metaTags = new TagCollection(Map(
-      MessagePackSerializer.ORG_ID -> "1",
-      MessagePackSerializer.INTERVAL -> "60"
-    ).asJava)
-    val metric = new MetricData(new MetricDefinition("a", tags, metaTags), 0.5202212202357678, 1533174724L)
+    val metric = new MetricData(new MetricDefinition("a", tags, TagCollection.EMPTY), 0.5202212202357678, 1533174724L)
     val metrics = List(metric).asJava
 
     it("should serialize a MetricData") {
@@ -84,44 +82,18 @@ class MessagePackSerializerTest extends FunSpec with Matchers with GivenWhenThen
       Given("A MetricData with no unit")
       val serializedMetricNoUnit = Base64.getDecoder.decode("iaJJZNkiMS5mNmJlZTcyZTU1OWI0ZDM4YmMwMWJhZmU5NWE3YjFlZaVPcmdJZAGkTmFtZaFhqEludGVydmFsPKVWYWx1ZctAyAAAAAAAAKRVbml0oKRUaW1l0wAAAABcNBY9pU10eXBlpWdhdWdlpFRhZ3OQ")
       val tagsEmptyUnit = new TagCollection(Map(
+        MessagePackSerializer.ORG_ID -> "1",
+        MessagePackSerializer.INTERVAL -> "60",
         MetricDefinition.UNIT -> "",
         MetricDefinition.MTYPE -> "gauge"
       ).asJava)
-      val metricNoUnit = new MetricData(new MetricDefinition("a", tagsEmptyUnit, metaTags), 12288, 1546917437L)
+      val metricNoUnit = new MetricData(new MetricDefinition("a", tagsEmptyUnit, TagCollection.EMPTY), 12288, 1546917437L)
 
       When("deserializing")
       val m = messagePackSerializer.deserialize(serializedMetricNoUnit)
 
       Then("the result should have a unit that is the empty string")
       m should be(metricNoUnit)
-    }
-
-    it("should preserve a tag named 'interval'") {
-      Given("A MetricData with a tag named 'interval'")
-      val serializedMetricWithInterval = Base64.getDecoder.decode("iaJJZNkiMS40Nzc1ODllNjhkNWIwMWI3Y2NhOGRkMDVmMmQwODY1M6VPcmdJZAGkTmFtZaFhqEludGVydmFsPKVWYWx1ZctAyAAAAAAAAKRVbml0oKRUaW1l0wAAAABcNBY9pU10eXBlpWdhdWdlpFRhZ3ORsmludGVydmFsPU9uZU1pbnV0ZQ==")
-      val tagsWithInterval = new TagCollection(Map(
-        "interval" -> "OneMinute",
-        MetricDefinition.UNIT -> "",
-        MetricDefinition.MTYPE -> "gauge"
-      ).asJava)
-      val metricWithInterval = new MetricData(new MetricDefinition("a", tagsWithInterval, metaTags), 12288, 1546917437L)
-
-      When("deserializing")
-      val m = messagePackSerializer.deserialize(serializedMetricWithInterval)
-
-      Then("the result should have an interval")
-      m should be(metricWithInterval)
-    }
-
-    it("should ignore a tag named 'unit'") {
-      Given("A MetricData with a tag named 'unit'")
-      val serializedMetricWithUnitTag = Base64.getDecoder.decode("iaJJZNkiMS5kOWM5OGY0NDU3YjZhYTA2YTA4ZTQwMWIwZmJjOTc3ZqVPcmdJZAGkTmFtZaFhqEludGVydmFsPKVWYWx1Zcs/4KWm+PMheaRVbml0oVCkVGltZc5bYmPEpU10eXBlpWdhdWdlpFRhZ3ORsXVuaXQ9bWljcm9zZWNvbmRz")
-
-      When("deserializing")
-      val m = messagePackSerializer.deserialize(serializedMetricWithUnitTag)
-
-      Then("the result should have the unit field, not the unit tag")
-      m should be(metric)
     }
 
   }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.expedia</groupId>
     <artifactId>metrics-java-root</artifactId>
-    <version>0.8.0</version>
+    <version>0.9.0</version>
     <packaging>pom</packaging>
 
     <name>metrics-java-root</name>


### PR DESCRIPTION
In release 0.7.0 we introduced some changes to facilitate integration
between Haystack and Adaptive Alerting. Unfortunately these changes broke
serialization and deserialization for existing Adaptive Alerting clients
and we need to roll them back.

The changes in 0.7.0 were anyway a temporary hack to support the aforesaid
integration. We will have to think of a more permanent way to handle this.