### PR TITLE
Add MetricTankMetricDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.10.0 2019-01-25
+### Added
+- Added MetricTankMetricDefinition which extends MetricDefinition with the orgId, interval, unit, and mtype fields required by metrictank
+
+### Changed
+- Removed the requirement that all metrics have tags unit and mtype. This means the data model in this library is more permissive that the Metrics 2.0 specification.
+
 ## 0.9.0 2019-01-23
 ### Changed
 - Reverted release 0.7.0 changes as they broke existing library clients.

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.expedia</groupId>
         <artifactId>metrics-java-root</artifactId>
-        <version>0.9.0</version>
+        <version>0.10.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.expedia</groupId>
         <artifactId>metrics-java-root</artifactId>
-        <version>0.9.0</version>
+        <version>0.10.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 </project>

--- a/main/src/main/java/com/expedia/metrics/MetricDefinition.java
+++ b/main/src/main/java/com/expedia/metrics/MetricDefinition.java
@@ -15,30 +15,21 @@
  */
 package com.expedia.metrics;
 
-import java.util.*;
+import java.util.Objects;
 
 public class MetricDefinition {
     public static final String UNIT = "unit";
     public static final String MTYPE = "mtype";
 
-    private static final List<String> REQUIRED_TAGS = Arrays.asList(UNIT, MTYPE);
-    private static final TagCollection MINIMAL_TAGS;
-    static {
-        Map<String, String> kv = new HashMap<>();
-        kv.put(MTYPE, "gauge");
-        kv.put(UNIT, "metric");
-        MINIMAL_TAGS = new TagCollection(kv);
-    }
-
-    private final String key;
-    private final TagCollection tags;
-    private final TagCollection meta;
+    protected final String key;
+    protected final TagCollection tags;
+    protected final TagCollection meta;
 
     /**
-     * Constructs a MetricDefinition with minimal tags and no meta tags
+     * Constructs a MetricDefinition with no tags and no meta tags
      */
     public MetricDefinition(String key) {
-        this(key, MINIMAL_TAGS, TagCollection.EMPTY);
+        this(key, TagCollection.EMPTY, TagCollection.EMPTY);
     }
 
     /**
@@ -61,11 +52,6 @@ public class MetricDefinition {
         }
         if (meta == null) {
             throw new IllegalArgumentException("meta is required. Use TagCollection.EMPTY if you have no meta tags");
-        }
-        for (String tag : REQUIRED_TAGS) {
-            if (!tags.getKv().containsKey(tag)) {
-                throw new IllegalArgumentException("Missing required tag: " + tag);
-            }
         }
         this.key = key;
         this.tags = tags;

--- a/main/src/test/scala/com/expedia/metrics/MetricDefinitionTest.scala
+++ b/main/src/test/scala/com/expedia/metrics/MetricDefinitionTest.scala
@@ -35,19 +35,5 @@ class MetricDefinitionTest extends FunSpec with Matchers  {
       val metric2 = new MetricDefinition(tags, meta2)
       metric1 should equal(metric2)
     }
-    it("should require a unit") {
-      val tags = new TagCollection(Map("mtype" -> "gauge").asJava)
-      an [IllegalArgumentException] should be thrownBy new MetricDefinition(tags, TagCollection.EMPTY)
-    }
-    it("should require an mtype") {
-      val tags = new TagCollection(Map("unit" -> "P").asJava)
-      an [IllegalArgumentException] should be thrownBy new MetricDefinition(tags, TagCollection.EMPTY)
-    }
-    it("should have an mtype and unit when created from a key") {
-      val metric = new MetricDefinition("test.key")
-      metric.getKey should be("test.key")
-      metric.getTags.getKv.get(MetricDefinition.MTYPE) should be("gauge")
-      metric.getTags.getKv.get(MetricDefinition.UNIT) should be("metric")
-    }
   }
 }

--- a/metrictank/pom.xml
+++ b/metrictank/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.expedia</groupId>
         <artifactId>metrics-java-root</artifactId>
-        <version>0.9.0</version>
+        <version>0.10.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/metrictank/src/main/java/com/expedia/metrics/metrictank/MetricTankIdFactory.java
+++ b/metrictank/src/main/java/com/expedia/metrics/metrictank/MetricTankIdFactory.java
@@ -23,12 +23,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.expedia.metrics.metrictank.MessagePackSerializer.INTERVAL;
-import static com.expedia.metrics.metrictank.MessagePackSerializer.ORG_ID;
 
 public class MetricTankIdFactory implements IdFactory {
     
@@ -38,32 +34,15 @@ public class MetricTankIdFactory implements IdFactory {
     }
     
     public MetricKey getKey(MetricDefinition metric) {
-        Map<String, String> tags = new HashMap<>(metric.getTags().getKv());
-        final int orgId;
-        try {
-            orgId = Integer.parseInt(tags.remove(ORG_ID));
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Tag 'org_id' must be an int", e);
-        }
+        final int orgId = MessagePackSerializer.getOrgId(metric);
         final String name = metric.getKey();
         if (name == null) {
             throw new IllegalArgumentException("Property 'key' is required by metrictank");
         }
-        final int interval;
-        try {
-            interval = Integer.parseInt(tags.remove(INTERVAL));
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Tag 'interval' must be an int", e);
-        }
-        final String unit = tags.remove(MetricDefinition.UNIT);
-        if (unit == null) {
-            throw new IllegalArgumentException("Tag 'unit' is required by metrictank");
-        }
-        final String mtype = tags.remove(MetricDefinition.MTYPE);
-        if (mtype == null) {
-            throw new IllegalArgumentException("Tag 'mtype' is required by metrictank");
-        }
-        List<String> formattedTags = formatTags(tags);
+        final int interval = MessagePackSerializer.getInterval(metric);
+        final String unit = MessagePackSerializer.getUnit(metric);
+        final String mtype = MessagePackSerializer.getMtype(metric);
+        List<String> formattedTags = formatTags(metric.getTags().getKv());
         return getKey(orgId, name, unit, mtype, interval, formattedTags);
     }
     

--- a/metrictank/src/main/java/com/expedia/metrics/metrictank/MetricTankMetricDefinition.java
+++ b/metrictank/src/main/java/com/expedia/metrics/metrictank/MetricTankMetricDefinition.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Expedia Group, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expedia.metrics.metrictank;
+
+import com.expedia.metrics.MetricDefinition;
+import com.expedia.metrics.TagCollection;
+
+import java.util.Objects;
+
+public class MetricTankMetricDefinition extends MetricDefinition {
+    private final int orgId;
+    private final int interval;
+    private final String unit;
+    private final String mtype;
+
+    public MetricTankMetricDefinition(String key, int orgId, int interval, String unit, String mtype) {
+        this(key, TagCollection.EMPTY, TagCollection.EMPTY, orgId, interval, unit, mtype);
+    }
+
+    public MetricTankMetricDefinition(String key, TagCollection tags, TagCollection meta, int orgId, int interval, String unit, String mtype) {
+        super(key, tags, meta);
+        this.orgId = orgId;
+        this.interval = interval;
+        if (unit == null) {
+            throw new IllegalArgumentException("Unit may not be null");
+        }
+        this.unit = unit;
+        if (mtype == null) {
+            throw new IllegalArgumentException("Mtype may not be null");
+        }
+        this.mtype = mtype;
+    }
+
+    public int getOrgId() {
+        return orgId;
+    }
+
+    public int getInterval() {
+        return interval;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public String getMtype() {
+        return mtype;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MetricTankMetricDefinition)) return false;
+        if (!super.equals(o)) return false;
+        MetricTankMetricDefinition that = (MetricTankMetricDefinition) o;
+        return orgId == that.orgId &&
+                interval == that.interval &&
+                unit.equals(that.unit) &&
+                mtype.equals(that.mtype);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), orgId, interval, unit, mtype);
+    }
+
+    @Override
+    public String toString() {
+        return "MetricTankMetricDefinition{" +
+                "orgId=" + orgId +
+                ", interval=" + interval +
+                ", unit='" + unit + '\'' +
+                ", mtype='" + mtype + '\'' +
+                ", key='" + key + '\'' +
+                ", tags=" + tags +
+                ", meta=" + meta +
+                '}';
+    }
+}

--- a/metrictank/src/test/scala/com/expedia/metrics/metrictank/MDMCachingDeserializerTest.scala
+++ b/metrictank/src/test/scala/com/expedia/metrics/metrictank/MDMCachingDeserializerTest.scala
@@ -37,8 +37,8 @@ class MDMCachingDeserializerTest extends FunSpec with Matchers with GivenWhenThe
     it("should be able to deserialise a MetricPoint if the MetricData has been seen") {
       Given("a serialized metric data and metricpoint with the same id")
       val deserializer = new MDMCachingDeserializer()
-      val metricDataBytes = Base64.getDecoder.decode("iaJJZNkiMS4yMGM3MjcxNzdiNzdhZTg5YmYzZmM5NWQwZmMzYmZhNKVPcmdJZAGkTmFtZdm0ZXdldGVzdC51cy13ZXN0LTIuc3RhdHMuZ2F1Z2VzLmV3cy1ib29raW5nLXNlcnZpY2UuMzJlNDBkLTUwNzEwN2IyNDliOC5tZXRyaWNzLnZmb3AuaG90ZWxzLmJvb2suRVdTQm9va2luZ1Rlc3RfUElJRExFU1MuRUNPTS43MC44MDgwYTAwYV81Yzk1XzQ5YjBfYjA0NF8wM2M4YTkyNjMwMTAuOTk5dGhQZXJjZW50aWxlqEludGVydmFsHqVWYWx1ZctALTAqVhTfi6RVbml0p3Vua25vd26kVGltZdJboHovpU10eXBlpWdhdWdlpFRhZ3OQ")
-      val metricPointBytes = Base64.getDecoder.decode("AiDHJxd7d66Jvz/JXQ/Dv6RALTAqVhTfi1ugei8BAAAA")
+      val metricDataBytes = Base64.getDecoder.decode("iaJJZNkiMS5kOWM5OGY0NDU3YjZhYTA2YTA4ZTQwMWIwZmJjOTc3ZqVPcmdJZAGkTmFtZaFhqEludGVydmFsPKVWYWx1Zcs/4KWm+PMheaRVbml0oVCkVGltZdMAAAAAW2JjxKVNdHlwZaVnYXVnZaRUYWdzkA==")
+      val metricPointBytes = Base64.getDecoder.decode("AtnJj0RXtqoGoI5AGw+8l3+sVCYs2tjjP+JjYlsBAAAA")
 
       When("deserialising the metric data and then the metric point")
       val metricData = deserializer.deserialize(ByteBuffer.wrap(metricDataBytes))

--- a/metrictank/src/test/scala/com/expedia/metrics/metrictank/MessagePackSerializerTest.scala
+++ b/metrictank/src/test/scala/com/expedia/metrics/metrictank/MessagePackSerializerTest.scala
@@ -29,13 +29,7 @@ class MessagePackSerializerTest extends FunSpec with Matchers with GivenWhenThen
     val serializedMetric = Base64.getDecoder.decode("iaJJZNkiMS5kOWM5OGY0NDU3YjZhYTA2YTA4ZTQwMWIwZmJjOTc3ZqVPcmdJZAGkTmFtZaFhqEludGVydmFsPKVWYWx1Zcs/4KWm+PMheaRVbml0oVCkVGltZdMAAAAAW2JjxKVNdHlwZaVnYXVnZaRUYWdzkA==")
     val serializedMetricList = Base64.getDecoder.decode("kYmiSWTZIjEuZDljOThmNDQ1N2I2YWEwNmEwOGU0MDFiMGZiYzk3N2alT3JnSWQBpE5hbWWhYahJbnRlcnZhbDylVmFsdWXLP+ClpvjzIXmkVW5pdKFQpFRpbWXTAAAAAFtiY8SlTXR5cGWlZ2F1Z2WkVGFnc5A=")
 
-    val tags = new TagCollection(Map(
-      MessagePackSerializer.ORG_ID -> "1",
-      MessagePackSerializer.INTERVAL -> "60",
-      MetricDefinition.UNIT -> "P",
-      MetricDefinition.MTYPE -> "gauge"
-    ).asJava)
-    val metric = new MetricData(new MetricDefinition("a", tags, TagCollection.EMPTY), 0.5202212202357678, 1533174724L)
+    val metric = new MetricData(new MetricTankMetricDefinition("a", TagCollection.EMPTY, TagCollection.EMPTY, 1, 60, "P", "gauge"), 0.5202212202357678, 1533174724L)
     val metrics = List(metric).asJava
 
     it("should serialize a MetricData") {
@@ -81,13 +75,7 @@ class MessagePackSerializerTest extends FunSpec with Matchers with GivenWhenThen
     it("should default to an empty unit when deserialising") {
       Given("A MetricData with no unit")
       val serializedMetricNoUnit = Base64.getDecoder.decode("iaJJZNkiMS5mNmJlZTcyZTU1OWI0ZDM4YmMwMWJhZmU5NWE3YjFlZaVPcmdJZAGkTmFtZaFhqEludGVydmFsPKVWYWx1ZctAyAAAAAAAAKRVbml0oKRUaW1l0wAAAABcNBY9pU10eXBlpWdhdWdlpFRhZ3OQ")
-      val tagsEmptyUnit = new TagCollection(Map(
-        MessagePackSerializer.ORG_ID -> "1",
-        MessagePackSerializer.INTERVAL -> "60",
-        MetricDefinition.UNIT -> "",
-        MetricDefinition.MTYPE -> "gauge"
-      ).asJava)
-      val metricNoUnit = new MetricData(new MetricDefinition("a", tagsEmptyUnit, TagCollection.EMPTY), 12288, 1546917437L)
+      val metricNoUnit = new MetricData(new MetricTankMetricDefinition("a", TagCollection.EMPTY, TagCollection.EMPTY, 1, 60, "", "gauge"), 12288, 1546917437L)
 
       When("deserializing")
       val m = messagePackSerializer.deserialize(serializedMetricNoUnit)

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.expedia</groupId>
     <artifactId>metrics-java-root</artifactId>
-    <version>0.9.0</version>
+    <version>0.10.0</version>
     <packaging>pom</packaging>
 
     <name>metrics-java-root</name>


### PR DESCRIPTION
This PR adds class `MetricTankMetricDefinition` which extends MetricDefinition with the orgId, interval, unit, and mtype fields required by metrictank. The metrictank serializers have been extended to preserve the metrictank fields in the new class.

Additionally `MetricDefinition` no longer requires that all metrics have tags `unit` and `mtype`